### PR TITLE
Add GitHub Action for Docker image publishing

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,60 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push metatool-web image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: runner
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-web:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-web:${{ github.sha }}
+
+      - name: Build and push metatool-remote-hosting image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./remote-hosting
+          file: ./remote-hosting/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:${{ github.sha }}
+
+      - name: Build and push drizzle-migrate image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: migrator
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/drizzle-migrate:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/drizzle-migrate:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ cp example.env .env
 docker compose up --build -d
 ```
 
+If you do not want to build the images locally, a prebuilt version of each
+service is published to the GitHub Container Registry.  You can run those
+images with the provided `docker-compose.images.yml` file:
+
+```bash
+docker compose -f docker-compose.images.yml up -d
+```
+
 Then open http://localhost:12005 in your browser to open MetaMCP App.
 
 It is recommended to have npx (node.js based mcp) and uvx (python based mcp) installed globally.

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -1,0 +1,59 @@
+services:
+  metatool-web:
+    container_name: metatool-web
+    image: ghcr.io/metatool-ai/metatool-app/metatool-web:latest
+    env_file:
+      - .env
+    restart: always
+    ports:
+      - '12005:3000'
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - metatool-postgres
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  metatool-remote-hosting:
+    container_name: metatool-remote-hosting
+    image: ghcr.io/metatool-ai/metatool-app/metatool-remote-hosting:latest
+    env_file:
+      - .env
+    restart: always
+    ports:
+      - '12007:12007'
+    environment:
+      - NODE_ENV=production
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  metatool-postgres:
+    container_name: metatool-postgres
+    image: postgres:16.2-alpine3.18
+    restart: always
+    environment:
+      POSTGRES_DB: metatool
+      POSTGRES_USER: metatool
+      POSTGRES_PASSWORD: m3t4t00l
+    ports:
+      - '8432:5432'
+    volumes:
+      - metatool-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U metatool" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  drizzle-migrate:
+    container_name: drizzle-migrate
+    image: ghcr.io/metatool-ai/metatool-app/drizzle-migrate:latest
+    env_file:
+      - .env
+    depends_on:
+      metatool-postgres:
+        condition: service_healthy
+
+volumes:
+  metatool-postgres:
+    driver: local


### PR DESCRIPTION
## Summary
- add workflow to publish Docker images to GitHub Container Registry
- provide docker-compose file using published images
- document how to run containers with prebuilt images

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6846f5dea95c83338c259701673d4911