### PR TITLE
Add migrator image and service

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -48,3 +48,14 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:${{ github.sha }}
 
+      - name: Build and push metatool-migrator image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: migrator
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:${{ github.sha }}
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ images with the provided `docker-compose.images.yml` file:
 docker compose -f docker-compose.images.yml up -d
 ```
 
+This compose file also starts a `drizzle-migrate` service that applies the
+database migrations before the application containers run.
+
 Then open http://localhost:12005 in your browser to open MetaMCP App.
 
 It is recommended to have npx (node.js based mcp) and uvx (python based mcp) installed globally.

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -1,7 +1,7 @@
 services:
   metatool-web:
     container_name: metatool-web
-    image: ghcr.io/metatool-ai/metatool-app/metatool-web:latest
+    image: ghcr.io/ilyavolodin/metatool-app/metatool-web:latest
     env_file:
       - .env
     restart: always
@@ -16,7 +16,7 @@ services:
 
   metatool-remote-hosting:
     container_name: metatool-remote-hosting
-    image: ghcr.io/metatool-ai/metatool-app/metatool-remote-hosting:latest
+    image: ghcr.io/ilyavolodin/metatool-app/metatool-remote-hosting:latest
     env_file:
       - .env
     restart: always
@@ -44,6 +44,15 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  drizzle-migrate:
+    container_name: drizzle-migrate
+    image: ghcr.io/ilyavolodin/metatool-app/metatool-migrator:latest
+    env_file:
+      - .env
+    depends_on:
+      metatool-postgres:
+        condition: service_healthy
 
 
 volumes:


### PR DESCRIPTION
## Summary
- include `drizzle-migrate` service in `docker-compose.images.yml`
- publish a `metatool-migrator` Docker image in CI
- note the migration service in the README
- update image names for ilyavolodin fork

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6847155d05e48333b3a4aae1c7176530