### PR TITLE
Add MCP server start logging

### DIFF
--- a/remote-hosting/src/transports.ts
+++ b/remote-hosting/src/transports.ts
@@ -46,7 +46,17 @@ export const createTransport = async (req: express.Request): Promise<Transport> 
       stderr: 'pipe',
     });
 
-    await transport.start();
+    console.log(`Starting MCP server process: ${cmd} ${args.join(' ')}`);
+    try {
+      await transport.start();
+      console.log(`MCP server started: ${cmd} ${args.join(' ')}`);
+    } catch (error) {
+      console.error(
+        `Failed to start MCP server process: ${cmd} ${args.join(' ')}`,
+        error
+      );
+      throw error;
+    }
 
     // Handle stderr output - pipe to console without blocking
     if (transport.stderr) {
@@ -174,7 +184,17 @@ export const createMetaMcpTransport = async (apiKey: string): Promise<Transport>
     stderr: 'pipe',
   });
 
-  await transport.start();
+  console.log(`Starting MetaMCP server process: ${cmd} ${args.join(' ')}`);
+  try {
+    await transport.start();
+    console.log(`MetaMCP server started: ${cmd} ${args.join(' ')}`);
+  } catch (error) {
+    console.error(
+      `Failed to start MetaMCP server process: ${cmd} ${args.join(' ')}`,
+      error
+    );
+    throw error;
+  }
 
   // Handle stderr output - pipe to console without blocking
   if (transport.stderr) {


### PR DESCRIPTION
## Summary
- add logs when starting stdio transports
- add logs when starting MetaMCP server transports

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478cbd7aa88333a1427c53faace13e