### PR TITLE
Improve remote logging & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,35 @@ Then open http://localhost:12005 in your browser to open MetaMCP App.
 It is recommended to have npx (node.js based mcp) and uvx (python based mcp) installed globally.
 To install uv check: https://docs.astral.sh/uv/getting-started/installation/
 
-### Default Remote Mode SSE endpoint for MetaMCP
+### Default Remote Mode Streaming HTTP endpoint for MetaMCP
 
-The recommended way to connect to MetaMCP is via the SSE endpoint:
+The recommended way to connect to MetaMCP is via the streaming HTTP endpoint:
 
 ```
-http://localhost:12007/sse with Authorization: Bearer <your-api-key>
+http://localhost:12007/mcp with Authorization: Bearer <your-api-key>
 ```
 
 Alternatively, if you cannot set headers, you can use this URL-based endpoint:
 
 ```
-http://localhost:12007/api-key/<your-api-key>/sse
+http://localhost:12007/api-key/<your-api-key>/mcp
 ```
 
 You can get the API key from the MetaMCP App's API Keys page.
+
+### Legacy SSE endpoint
+
+The SSE protocol is still available for backwards compatibility:
+
+```
+http://localhost:12007/sse with Authorization: Bearer <your-api-key>
+```
+
+or
+
+```
+http://localhost:12007/api-key/<your-api-key>/sse
+```
 
 ### For Local Access
 

--- a/remote-hosting/src/mcpProxy.ts
+++ b/remote-hosting/src/mcpProxy.ts
@@ -18,11 +18,22 @@ export default function mcpProxy({
   let transportToClientClosed = false;
   let transportToServerClosed = false;
 
+  function logMessage(direction: string, message: any) {
+    if (message && typeof message === 'object' && 'method' in message) {
+      const method = String((message as any).method).toLowerCase();
+      if (method.includes('tool')) {
+        console.log(`[${direction}] ${method}`);
+      }
+    }
+  }
+
   transportToClient.onmessage = (message) => {
+    logMessage('client->server', message);
     transportToServer.send(message).catch(onServerError);
   };
 
   transportToServer.onmessage = (message) => {
+    logMessage('server->client', message);
     transportToClient.send(message).catch(onClientError);
   };
 

--- a/remote-hosting/src/routes/api-key/streamable-http.ts
+++ b/remote-hosting/src/routes/api-key/streamable-http.ts
@@ -89,6 +89,20 @@ export const handleApiKeyUrlMcpPost = async (req: express.Request, res: express.
         });
   
         await webAppTransport.start();
+
+        webAppTransport.onclose = async () => {
+          const id = webAppTransport.sessionId;
+          console.log(`Connection closed for session ${id}`);
+          const conn = metaMcpConnections.get(id || '');
+          if (conn?.backingServerTransport) {
+            try {
+              await conn.backingServerTransport.close();
+            } catch (err) {
+              console.error('Error closing backing transport:', err);
+            }
+          }
+          metaMcpConnections.delete(id || '');
+        };
   
         if (backingServerTransport instanceof StdioClientTransport && backingServerTransport.stderr) {
           backingServerTransport.stderr.on('data', (chunk) => {


### PR DESCRIPTION
## Summary
- log tool-related messages and connection state in remote-hosting
- close transports when a streamable HTTP session ends
- document streaming HTTP and legacy SSE endpoints

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68478d01904083338093ba70a650deed