### PR TITLE
Fix proxy health check

### DIFF
--- a/app/api/proxy-health/route.ts
+++ b/app/api/proxy-health/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+import * as logger from '@/lib/logger';
+
+export async function GET() {
+  try {
+    const proxyHealthUrl = process.env.USE_DOCKER_HOST === 'true'
+      ? 'http://host.docker.internal:12007/health'
+      : 'http://localhost:12007/health';
+
+    const response = await fetch(proxyHealthUrl);
+    const json = await response.json();
+    return NextResponse.json(json);
+  } catch (error) {
+    logger.error('Proxy health check failed', error);
+    return NextResponse.json(
+      { error: 'Proxy health check failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/hooks/useConnection.ts
+++ b/hooks/useConnection.ts
@@ -233,12 +233,8 @@ export function useConnection({
 
   const checkProxyHealth = async () => {
     try {
-      const proxyHealthUrl = new URL(
-        process.env.USE_DOCKER_HOST === 'true'
-          ? `http://host.docker.internal:12007/health`
-          : `http://localhost:12007/health`
-      );
-      logger.log('Checking proxy health', proxyHealthUrl.toString());
+      const proxyHealthUrl = '/api/proxy-health';
+      logger.log('Checking proxy health via', proxyHealthUrl);
       const proxyHealthResponse = await fetch(proxyHealthUrl);
       const proxyHealth = await proxyHealthResponse.json();
       if (proxyHealth?.status !== 'ok') {

--- a/hooks/useConnectionMulti.ts
+++ b/hooks/useConnectionMulti.ts
@@ -60,11 +60,7 @@ export function useConnectionMulti({
   // Utility function to check if the MCP proxy is healthy
   const checkProxyHealth = async () => {
     try {
-      const proxyHealthUrl = new URL(
-        process.env.USE_DOCKER_HOST === 'true'
-          ? `http://host.docker.internal:12007/health`
-          : `http://localhost:12007/health`
-      );
+      const proxyHealthUrl = '/api/proxy-health';
       const proxyHealthResponse = await fetch(proxyHealthUrl);
       const proxyHealth = await proxyHealthResponse.json();
       if (proxyHealth?.status !== 'ok') {


### PR DESCRIPTION
## Summary
- add new `/api/proxy-health` endpoint that fetches the health data server‑side
- update hooks to query this API instead of calling `localhost`

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6848792bab6c8333913ba2651d13be16