### PR TITLE
Add unified nginx proxy at /host path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ To install uv check: https://docs.astral.sh/uv/getting-started/installation/
 The recommended way to connect to MetaMCP is via the streaming HTTP endpoint:
 
 ```
-http://localhost:12007/mcp with Authorization: Bearer <your-api-key>
+http://localhost:12005/host/mcp with Authorization: Bearer <your-api-key>
 ```
 
 Alternatively, if you cannot set headers, you can use this URL-based endpoint:
 
 ```
-http://localhost:12007/api-key/<your-api-key>/mcp
+http://localhost:12005/host/api-key/<your-api-key>/mcp
 ```
 
 You can get the API key from the MetaMCP App's API Keys page.
@@ -73,13 +73,13 @@ You can get the API key from the MetaMCP App's API Keys page.
 The SSE protocol is still available for backwards compatibility:
 
 ```
-http://localhost:12007/sse with Authorization: Bearer <your-api-key>
+http://localhost:12005/host/sse with Authorization: Bearer <your-api-key>
 ```
 
 or
 
 ```
-http://localhost:12007/api-key/<your-api-key>/sse
+http://localhost:12005/host/api-key/<your-api-key>/sse
 ```
 
 ### For Local Access

--- a/app/(sidebar-layout)/(container)/inspector-guide/page.tsx
+++ b/app/(sidebar-layout)/(container)/inspector-guide/page.tsx
@@ -18,8 +18,8 @@ export default function InspectorGuidePage() {
 
   const inspectorCommand = `npx -y @modelcontextprotocol/inspector npx -y @metamcp/mcp-server-metamcp@latest -e METAMCP_API_KEY=${apiKey?.api_key || '<YOUR_API_KEY>'} -e METAMCP_API_BASE_URL=http://localhost:12005`;
 
-  const sseEndpoint = `http://localhost:12007/sse with Authorization: Bearer ${apiKey?.api_key || '<YOUR_API_KEY>'}`;
-  const urlBasedSseEndpoint = `http://localhost:12007/api-key/${apiKey?.api_key || '<YOUR_API_KEY>'}/sse`;
+  const sseEndpoint = `http://localhost:12005/host/sse with Authorization: Bearer ${apiKey?.api_key || '<YOUR_API_KEY>'}`;
+  const urlBasedSseEndpoint = `http://localhost:12005/host/api-key/${apiKey?.api_key || '<YOUR_API_KEY>'}/sse`;
 
   return (
     <div className='container mx-auto py-6 flex flex-col items-start justify-center gap-6'>

--- a/app/(sidebar-layout)/(container)/setup-guide/page.tsx
+++ b/app/(sidebar-layout)/(container)/setup-guide/page.tsx
@@ -65,7 +65,7 @@ export default function SetupGuidePage() {
           <div className='relative mb-6'>
             <button
               onClick={() => {
-                const endpoint = `http://localhost:12007/sse with Authorization: Bearer ${apiKey?.api_key ?? '<create an api key first>'}`;
+                const endpoint = `http://localhost:12005/host/sse with Authorization: Bearer ${apiKey?.api_key ?? '<create an api key first>'}`;
                 navigator.clipboard.writeText(endpoint);
                 toast({
                   description: 'API endpoint copied to clipboard',
@@ -77,7 +77,7 @@ export default function SetupGuidePage() {
             </button>
             <Highlight
               theme={themes.github}
-              code={`http://localhost:12007/sse with Authorization: Bearer ${apiKey?.api_key ?? '<create an api key first>'}`}
+              code={`http://localhost:12005/host/sse with Authorization: Bearer ${apiKey?.api_key ?? '<create an api key first>'}`}
               language='bash'>
               {({ tokens, getLineProps, getTokenProps }) => (
                 <pre className='bg-[#f6f8fa] text-[#24292f] p-4 rounded-md overflow-x-auto'>
@@ -100,7 +100,7 @@ export default function SetupGuidePage() {
           <div className='relative'>
             <button
               onClick={() => {
-                const endpoint = `http://localhost:12007/api-key/${apiKey?.api_key ?? '<create an api key first>'}/sse`;
+                const endpoint = `http://localhost:12005/host/api-key/${apiKey?.api_key ?? '<create an api key first>'}/sse`;
                 navigator.clipboard.writeText(endpoint);
                 toast({
                   description: 'URL-based API endpoint copied to clipboard',
@@ -112,7 +112,7 @@ export default function SetupGuidePage() {
             </button>
             <Highlight
               theme={themes.github}
-              code={`http://localhost:12007/api-key/${apiKey?.api_key ?? '<create an api key first>'}/sse`}
+              code={`http://localhost:12005/host/api-key/${apiKey?.api_key ?? '<create an api key first>'}/sse`}
               language='bash'>
               {({ tokens, getLineProps, getTokenProps }) => (
                 <pre className='bg-[#f6f8fa] text-[#24292f] p-4 rounded-md overflow-x-auto'>

--- a/app/api/proxy-health/route.ts
+++ b/app/api/proxy-health/route.ts
@@ -4,9 +4,7 @@ import * as logger from '@/lib/logger';
 
 export async function GET() {
   try {
-    const proxyHealthUrl = process.env.USE_DOCKER_HOST === 'true'
-      ? 'http://host.docker.internal:12007/health'
-      : 'http://localhost:12007/health';
+    const proxyHealthUrl = `${process.env.REMOTE_HOSTING_URL || 'http://localhost:12005/host'}/health`;
 
     const response = await fetch(proxyHealthUrl);
     const json = await response.json();

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -5,8 +5,7 @@ services:
     env_file:
       - .env
     restart: always
-    ports:
-      - '12005:3000'
+    # Expose ports only through nginx
     environment:
       - NODE_ENV=production
     depends_on:
@@ -20,8 +19,7 @@ services:
     env_file:
       - .env
     restart: always
-    ports:
-      - '12007:12007'
+    # Expose ports only through nginx
     environment:
       - NODE_ENV=production
     extra_hosts:
@@ -53,6 +51,17 @@ services:
     depends_on:
       metatool-postgres:
         condition: service_healthy
+
+  nginx:
+    container_name: metatool-nginx
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    ports:
+      - "12005:12005"
+    depends_on:
+      - metatool-web
+      - metatool-remote-hosting
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     env_file:
       - .env
     restart: always
-    ports:
-      - '12005:3000'
+    # Expose ports only through nginx
     environment:
       - NODE_ENV=production
     depends_on:
@@ -25,8 +24,7 @@ services:
     env_file:
       - .env
     restart: always
-    ports:
-      - '12007:12007'
+    # Expose ports only through nginx
     environment:
       - NODE_ENV=production
     extra_hosts:
@@ -62,6 +60,17 @@ services:
     depends_on:
       metatool-postgres:
         condition: service_healthy
+
+  nginx:
+    container_name: metatool-nginx
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    ports:
+      - "12005:12005"
+    depends_on:
+      - metatool-web
+      - metatool-remote-hosting
 
 volumes:
   metatool-postgres:

--- a/example.env
+++ b/example.env
@@ -1,3 +1,6 @@
 DATABASE_URL=postgresql://metatool:m3t4t00l@metatool-postgres:5432/metatool
 USE_DOCKER_HOST=true
+REMOTE_HOSTING_URL=http://metatool-nginx:12005/host
+METAMCP_API_BASE_URL=http://metatool-web:3000
+NEXT_PUBLIC_REMOTE_HOSTING_URL=http://localhost:12005/host
 

--- a/hooks/useConnection.ts
+++ b/hooks/useConnection.ts
@@ -233,10 +233,8 @@ export function useConnection({
 
   const checkProxyHealth = async () => {
     try {
-      const proxyHealthUrl = new URL(
-        process.env.USE_DOCKER_HOST === 'true'
-          ? 'http://host.docker.internal:12007/health'
-          : 'http://localhost:12007/health'
+    const proxyHealthUrl = new URL(
+        `${process.env.NEXT_PUBLIC_REMOTE_HOSTING_URL || 'http://localhost:12005/host'}/health`
       );
       logger.log('Checking proxy health', proxyHealthUrl.toString());
       const proxyHealthResponse = await fetch(proxyHealthUrl);
@@ -305,10 +303,8 @@ export function useConnection({
       return;
     }
     const mcpProxyServerUrl = new URL(
-      process.env.USE_DOCKER_HOST === 'true'
-        ? `http://host.docker.internal:12007/server/${mcpServerUuid}/sse`
-        : `http://localhost:12007/server/${mcpServerUuid}/sse`
-    );
+        `${process.env.NEXT_PUBLIC_REMOTE_HOSTING_URL || 'http://localhost:12005/host'}/server/${mcpServerUuid}/sse`
+      );
     mcpProxyServerUrl.searchParams.append(
       'transportType',
       mcpServer.type.toLowerCase()

--- a/hooks/useConnectionMulti.ts
+++ b/hooks/useConnectionMulti.ts
@@ -60,10 +60,8 @@ export function useConnectionMulti({
   // Utility function to check if the MCP proxy is healthy
   const checkProxyHealth = async () => {
     try {
-      const proxyHealthUrl = new URL(
-        process.env.USE_DOCKER_HOST === 'true'
-          ? 'http://host.docker.internal:12007/health'
-          : 'http://localhost:12007/health'
+    const proxyHealthUrl = new URL(
+        `${process.env.NEXT_PUBLIC_REMOTE_HOSTING_URL || 'http://localhost:12005/host'}/health`
       );
       const proxyHealthResponse = await fetch(proxyHealthUrl);
       const proxyHealth = await proxyHealthResponse.json();
@@ -160,9 +158,7 @@ export function useConnectionMulti({
 
     // Create proxy URL
     const mcpProxyServerUrl = new URL(
-      process.env.USE_DOCKER_HOST === 'true'
-        ? `http://host.docker.internal:12007/server/${serverUuid}/sse`
-        : `http://localhost:12007/server/${serverUuid}/sse`
+      `${process.env.NEXT_PUBLIC_REMOTE_HOSTING_URL || 'http://localhost:12005/host'}/server/${serverUuid}/sse`
     );
     mcpProxyServerUrl.searchParams.append(
       'transportType',

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,22 @@
+server {
+    listen 12005;
+
+    # Routes starting with /host/ are proxied to the remote-hosting container
+    location /host/ {
+        rewrite ^/host/(.*)$ /$1 break;
+        proxy_pass http://metatool-remote-hosting:12007/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Everything else goes to the web container
+    location / {
+        proxy_pass http://metatool-web:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/remote-hosting/src/transports.ts
+++ b/remote-hosting/src/transports.ts
@@ -178,9 +178,10 @@ export const createMetaMcpTransport = async (apiKey: string): Promise<Transport>
     ...defaultEnvironment,
     METAMCP_API_KEY: apiKey,
     METAMCP_API_BASE_URL:
-      process.env.USE_DOCKER_HOST === 'true'
+      process.env.METAMCP_API_BASE_URL ||
+      (process.env.USE_DOCKER_HOST === 'true'
         ? 'http://host.docker.internal:12005'
-        : 'http://localhost:12005',
+        : 'http://localhost:12005'),
     USE_DOCKER_HOST: process.env.USE_DOCKER_HOST,
   };
 


### PR DESCRIPTION
## Summary
- update nginx config to use a single server
- route `/host/*` to remote-hosting and everything else to the web app
- expose only port 12005 from nginx in docker compose
- update environment variables and docs to use `/host` prefix
- adjust code and examples to the new URL scheme

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ad61bd948333af0009af0261957c