### PR TITLE
Build nginx image

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -59,3 +59,13 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:${{ github.sha }}
 
+      - name: Build and push metatool-nginx image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./nginx
+          file: ./nginx/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-nginx:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-nginx:${{ github.sha }}
+

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ docker compose up --build -d
 ```
 
 If you do not want to build the images locally, a prebuilt version of each
-service is published to the GitHub Container Registry.  You can run those
-images with the provided `docker-compose.images.yml` file:
+service (including the nginx reverse proxy) is published to the GitHub
+Container Registry.  You can run those images with the provided
+`docker-compose.images.yml` file:
 
 ```bash
 docker compose -f docker-compose.images.yml up -d

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -54,9 +54,7 @@ services:
 
   nginx:
     container_name: metatool-nginx
-    build:
-      context: ./nginx
-      dockerfile: Dockerfile
+    image: ghcr.io/ilyavolodin/metatool-app/metatool-nginx:latest
     ports:
       - "12005:12005"
     depends_on:


### PR DESCRIPTION
## Summary
- build and publish a metatool-nginx image
- pull the nginx image via `docker-compose.images.yml`
- document the nginx image availability in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848c0820a348333b7d810c89aff8059