### PR TITLE
Add type checks to CI and parallelize workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,45 @@ on:
   pull_request:
 
 jobs:
-  lint-and-test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: |
+          pnpm install --ignore-scripts
+          pnpm --dir remote-hosting install --ignore-scripts
+      - name: Lint
+        run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: |
+          pnpm install --ignore-scripts
+          pnpm --dir remote-hosting install --ignore-scripts
+      - name: TypeScript type check
+        run: |
+          pnpm exec tsc --noEmit
+          pnpm --dir remote-hosting exec tsc --noEmit
+
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +55,5 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --ignore-scripts
-      - name: Lint
-        run: pnpm lint
       - name: Test
         run: pnpm test

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,6 +16,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - name: metatool-web
+            context: .
+            file: Dockerfile
+            target: runner
+          - name: metatool-remote-hosting
+            context: ./remote-hosting
+            file: ./remote-hosting/Dockerfile
+          - name: metatool-migrator
+            context: .
+            file: Dockerfile
+            target: migrator
+          - name: metatool-nginx
+            context: ./nginx
+            file: ./nginx/Dockerfile
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,45 +44,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push metatool-web image
+      - name: Build and push ${{ matrix.name }} image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: Dockerfile
-          target: runner
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-web:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-web:${{ github.sha }}
-
-      - name: Build and push metatool-remote-hosting image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./remote-hosting
-          file: ./remote-hosting/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-remote-hosting:${{ github.sha }}
-
-      - name: Build and push metatool-migrator image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: migrator
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-migrator:${{ github.sha }}
-
-      - name: Build and push metatool-nginx image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./nginx
-          file: ./nginx/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-nginx:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/metatool-nginx:${{ github.sha }}
-
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.name }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.name }}:${{ github.sha }}

--- a/remote-hosting/src/routes/legacy.ts
+++ b/remote-hosting/src/routes/legacy.ts
@@ -65,18 +65,8 @@ export const handleLegacySse = async (req: express.Request, res: express.Respons
     console.log('Web app transport started');
 
     if (backingServerTransport instanceof StdioClientTransport) {
-      if (backingServerTransport.stdout) {
-        backingServerTransport.stdout.on('data', (chunk) => {
-          console.log(`[stdout ${uuid}] ${chunk.toString().trim()}`);
-        });
-
-        backingServerTransport.stdout.on('error', (err) => {
-          console.error(`[stdout ${uuid}] error:`, err);
-        });
-      }
-
       if (backingServerTransport.stderr) {
-        backingServerTransport.stderr.on('data', (chunk) => {
+        backingServerTransport.stderr.on('data', (chunk: Buffer) => {
           webAppTransport.send({
             jsonrpc: '2.0',
             method: 'notifications/stderr',

--- a/remote-hosting/src/server.ts
+++ b/remote-hosting/src/server.ts
@@ -83,7 +83,7 @@ server.on('close', () => {
   console.log('Proxy server closed');
 });
 
-server.on('error', (err) => {
+server.on('error', (err: NodeJS.ErrnoException) => {
   if (err.message.includes(`EADDRINUSE`)) {
     console.error(`❌  Proxy Server PORT IS IN USE at port ${PORT} ❌ `);
   } else {

--- a/remote-hosting/src/transports.ts
+++ b/remote-hosting/src/transports.ts
@@ -45,7 +45,6 @@ export const createTransport = async (req: express.Request): Promise<Transport> 
       args,
       env,
       stderr: 'pipe',
-      stdout: 'pipe',
     });
 
     console.log(`Starting MCP server process: ${cmd} ${args.join(' ')}`);
@@ -66,23 +65,12 @@ export const createTransport = async (req: express.Request): Promise<Transport> 
       throw error;
     }
 
-    // Handle stdout/stderr output - pipe to console without blocking
-    if (transport.stdout) {
-      transport.stdout.on('data', (chunk) => {
-        console.log(`[${cmd}] ${chunk.toString().trim()}`);
-      });
-
-      transport.stdout.on('error', (error) => {
-        console.error(`[${cmd}] stdout error:`, error);
-      });
-    }
-
     if (transport.stderr) {
-      transport.stderr.on('data', (chunk) => {
+      transport.stderr.on('data', (chunk: Buffer) => {
         console.error(`[${cmd}] ${chunk.toString().trim()}`);
       });
 
-      transport.stderr.on('error', (error) => {
+      transport.stderr.on('error', (error: Error) => {
         console.error(`[${cmd}] stderr error:`, error);
       });
     }
@@ -205,7 +193,6 @@ export const createMetaMcpTransport = async (apiKey: string): Promise<Transport>
     args,
     env,
     stderr: 'pipe',
-    stdout: 'pipe',
   });
 
   console.log(`Starting MetaMCP server process: ${cmd} ${args.join(' ')}`);
@@ -226,23 +213,12 @@ export const createMetaMcpTransport = async (apiKey: string): Promise<Transport>
     throw error;
   }
 
-  // Handle stdout/stderr output - pipe to console without blocking
-  if (transport.stdout) {
-    transport.stdout.on('data', (chunk) => {
-      console.log(`[Sub MCP] ${chunk.toString().trim()}`);
-    });
-
-    transport.stdout.on('error', (error) => {
-      console.error(`[Sub MCP] Stdout error:`, error);
-    });
-  }
-
   if (transport.stderr) {
-    transport.stderr.on('data', (chunk) => {
+    transport.stderr.on('data', (chunk: Buffer) => {
       console.error(`[Sub MCP] ${chunk.toString().trim()}`);
     });
 
-    transport.stderr.on('error', (error) => {
+    transport.stderr.on('error', (error: Error) => {
       console.error(`[Sub MCP] Stderr error:`, error);
     });
   }


### PR DESCRIPTION
## Summary
- add separate jobs for lint, typechecking and tests
- run TypeScript type checking in CI for both the main app and remote-hosting package
- parallelize docker image builds using a matrix
- fix TypeScript errors in remote-hosting project

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm --dir remote-hosting exec tsc --noEmit`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848e97b6dd08333bf791d5592befdee