### PR TITLE
Fix missing API key on MCP connections

### DIFF
--- a/app/(sidebar-layout)/(container)/mcp-servers/[uuid]/page.tsx
+++ b/app/(sidebar-layout)/(container)/mcp-servers/[uuid]/page.tsx
@@ -102,6 +102,7 @@ export default function McpServerDetailPage({
   } = useConnection({
     mcpServerUuid: uuid,
     currentProfileUuid: currentProfile?.uuid,
+    bearerToken: apiKey?.api_key,
     onNotification: handleNotification,
     onStdErrNotification: handleNotification,
   });

--- a/app/(sidebar-layout)/(container)/tool-management/page.tsx
+++ b/app/(sidebar-layout)/(container)/tool-management/page.tsx
@@ -47,12 +47,17 @@ export default function ToolsManagementPage() {
     const [refreshingServers, setRefreshingServers] = useState<Set<string>>(new Set());
     const { mutate: globalMutate } = useSWRConfig();
 
+    const { data: apiKey } = useSWR(
+        currentProject?.uuid ? `${currentProject?.uuid}/api-keys/getFirst` : null,
+        () => getFirstApiKey(currentProject?.uuid || '')
+    );
+
     const {
         connectionStatuses,
         connect,
         disconnect,
         makeRequest
-    } = useConnectionMulti();
+    } = useConnectionMulti({ bearerToken: apiKey?.api_key });
 
     const hasToolsManagement = currentProfile?.enabled_capabilities?.includes(ProfileCapability.TOOLS_MANAGEMENT);
 
@@ -67,11 +72,6 @@ export default function ToolsManagementPage() {
             setExpandedServers(new Set(mcpServers.map(server => server.uuid)));
         }
     }, [mcpServers]);
-
-    const { data: apiKey } = useSWR(
-        currentProject?.uuid ? `${currentProject?.uuid}/api-keys/getFirst` : null,
-        () => getFirstApiKey(currentProject?.uuid || '')
-    );
 
     const allToolsData = useSWR(
         mcpServers && mcpServers.length > 0 ? ['allTools', mcpServers.map(s => s.uuid)] : null,

--- a/hooks/useConnectionMulti.ts
+++ b/hooks/useConnectionMulti.ts
@@ -27,11 +27,13 @@ interface UseConnectionMultiOptions {
     serverUuid: string,
     notification: Notification
   ) => void;
+  bearerToken?: string;
 }
 
 export function useConnectionMulti({
   onNotification,
   onStdErrNotification,
+  bearerToken,
 }: UseConnectionMultiOptions = {}) {
   const { currentProfile } = useProfiles();
   const { toast } = useToast();
@@ -161,7 +163,7 @@ export function useConnectionMulti({
 
       // Prepare auth headers
       const headers: HeadersInit = {};
-      const token = (await authProvider.tokens())?.access_token;
+      const token = bearerToken || (await authProvider.tokens())?.access_token;
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }


### PR DESCRIPTION
## Summary
- allow `useConnectionMulti` to accept a `bearerToken` for authorization
- pass API key from the database to MCP connections in server details and tool management pages

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f61513d0833384f6dac3c4885974